### PR TITLE
Add url under slug field, copy url action

### DIFF
--- a/src/Filament/Resources/PageResource/Pages/ListPages.php
+++ b/src/Filament/Resources/PageResource/Pages/ListPages.php
@@ -111,9 +111,9 @@ class ListPages extends TreeViewRecords
     {
         return collect(config('filament-template.pages', []))->mapWithKeys(function ($template) {
             $templateName = explode('\\', $template);
-            $templateName = Str::of(end($templateName))->replace('Template', '');
+            $templateName = Str::of(end($templateName))->replace('Template', '')->toString();
 
-            return [$template => end($templateName)];
+            return [$template => $templateName];
         });
     }
 

--- a/src/Traits/PageFormTrait.php
+++ b/src/Traits/PageFormTrait.php
@@ -6,6 +6,7 @@ use CubeAgency\FilamentJson\Filament\Forms\Components\Json;
 use CubeAgency\FilamentPageManager\Models\Page;
 use CubeAgency\FilamentTemplate\FilamentTemplate;
 use CubeAgency\FilamentTemplate\Forms\Components\Template;
+use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Grid;
@@ -19,6 +20,7 @@ use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Forms\Set;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 
 trait PageFormTrait
@@ -34,14 +36,43 @@ trait PageFormTrait
                                 TextInput::make('name')
                                     ->required()
                                     ->live(debounce: 500)
-                                    ->afterStateUpdated(fn(Set $set, ?string $state) => $set('slug', Str::slug($state))),
+                                    ->afterStateUpdated(fn (Set $set, ?string $state) => $set('slug', Str::slug($state))),
 
                                 TextInput::make('slug')
                                     ->prefix(function ($record) {
-                                        return config('app.url') . '/' . ($record ? $record->getUri(false) : '');
+                                        $currentRecord = $this->getCurrentRecord($record);
+
+                                        return $this->getRecordUrl(record: $currentRecord, withThis: ! $record);
                                     })
                                     ->required()
-                                    ->unique(Page::class, 'slug', fn($record) => $record),
+                                    ->reactive()
+                                    ->afterStateUpdated(function ($state, callable $set) {
+                                        $set('slug', Str::slug($state));
+                                    })
+                                    ->unique(Page::class, 'slug', fn ($record) => $record)
+                                    ->suffixAction(
+                                        Action::make('copy')
+                                            ->icon('heroicon-m-clipboard')
+                                            ->alpineClickHandler(function ($record, $state) {
+                                                $currentRecord = $this->getCurrentRecord($record);
+                                                $url = $this->getRecordUrl(record: $currentRecord, state: $state, withThis: ! $record);
+
+                                                return '
+                                                    window.navigator.clipboard.writeText("' . $url . '");
+                                                    $tooltip(\'Copied\', {theme: $store.theme, timeout: 2000})
+                                                ';
+                                            }),
+                                    )
+                                    ->helperText(function ($record, $state) {
+                                        if (! $record) {
+                                            return '';
+                                        }
+
+                                        $currentRecord = $this->getCurrentRecord($record);
+                                        $url = $this->getRecordUrl(record: $currentRecord, state: $state);
+
+                                        return new HtmlString('<a href="' . $url . '" class="text-primary-600" target="_blank">' . $url . '</a>');
+                                    }),
 
                                 Json::make('meta')
                                     ->schema([
@@ -56,7 +87,7 @@ trait PageFormTrait
                                                     ->rows(3),
                                                 FileUpload::make('image')
                                                     ->image()
-                                                    ->imagePreviewHeight('64')
+                                                    ->imagePreviewHeight('64'),
                                             ]),
                                     ]),
 
@@ -65,7 +96,7 @@ trait PageFormTrait
 
                                 Template::make('content')
                                     ->template($this->resolveTemplate()),
-                            ])
+                            ]),
                     ])
                     ->columnSpan(['lg' => 9]),
 
@@ -85,11 +116,11 @@ trait PageFormTrait
                                 Toggle::make('deactivate')
                                     ->label('Deactivate')
                                     ->live()
-                                    ->hidden(fn(?Model $record): bool => $record === null || !$record->active)
+                                    ->hidden(fn (?Model $record): bool => $record === null || ! $record->active)
                                     ->afterStateUpdated(function (Set $set) {
                                         $set('activate_at', null);
                                         $set('expire_at', null);
-                                    })
+                                    }),
                             ]),
                     ])
                     ->columnSpan(['lg' => 3]),
@@ -108,5 +139,21 @@ trait PageFormTrait
         }
 
         return $this->getRecord()->getAttribute('template');
+    }
+
+    protected function getCurrentRecord(?Model $record = null): ?Model
+    {
+        return $record ?? ($this->parentId ? Page::find($this->parentId) : null);
+    }
+
+    protected function getRecordUrl(?Model $record = null, $state = null, ?bool $withThis = false)
+    {
+        $state = $state === '/' ? '' : $state;
+
+        if ($record) {
+            return $record->getFullUrl($withThis) . $state;
+        }
+
+        return config('app.url') . '/' . $state;
     }
 }


### PR DESCRIPTION
- Add full url under slug field that opens in new tab
- Add suffix action to copy full url

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced form functionality with new methods for handling records and generating URLs.
	- Users can now copy the generated URL for the `slug` field directly to the clipboard.
	- Improved helper text for the `slug` field, including a clickable link to the generated URL.
	- Introduced a new method to construct a full URL for pages, incorporating ancestor slugs.

- **Bug Fixes**
	- Adjusted the `unique` method for the `slug` field to ensure it updates reactively with input changes.
	- Clarified string handling in the template retrieval process for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->