### PR TITLE
Add separate max_depth config for pages tree view

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ php artisan vendor:publish --tag="filament-page-manager-config"
 * **route_middleware**: Middleware applied to page routes.
 * **clear_obsolete_route_cache**: When set to true, clears obsolete routes from the cache (requires scheduler).
 * **refresh_route_cache**: When set to true, the route cache will be refreshed after changes.
+* **max_depth**: Controls the maximum nesting level of the tree view for pages.
 
 ## Usage
 

--- a/config/filament-page-manager.php
+++ b/config/filament-page-manager.php
@@ -8,4 +8,6 @@ return [
 
     'clear_obsolete_route_cache' => true,
     'refresh_route_cache' => true,
+
+    'max_depth' => 5,
 ];

--- a/src/Filament/Resources/PageResource/Pages/ListPages.php
+++ b/src/Filament/Resources/PageResource/Pages/ListPages.php
@@ -157,4 +157,9 @@ class ListPages extends TreeViewRecords
 
         return Str::of(end($template))->replace('Template', '');
     }
+
+    public function getMaxDepth(): int
+    {
+        return config('filament-page-manager.max_depth');
+    }
 }


### PR DESCRIPTION
Introduced a new configuration option, **max_depth**, which allows customization of the maximum nesting level for page tree views.
  